### PR TITLE
Limit send length

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "2.0.11"
 anyhow = "1.0.95"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+log = "0.4"
 rand = "0.8.5"
 
 [build-dependencies]

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -159,7 +159,10 @@ impl KcpConnection {
         // handle packet send
         let kcp = self.kcp.clone();
         let inner = self.inner.clone();
-        let mut send_receiver = self.send_receiver.take().unwrap();
+        let Some(mut send_receiver) = self.send_receiver.take() else {
+            tracing::error!("send receiver is not set");
+            return;
+        };
         let send_close_notifier = self.send_close_notifier.clone();
         self.tasks.spawn(
             async move {
@@ -178,7 +181,10 @@ impl KcpConnection {
                             break;
                         }
                     }
-                    kcp.lock().send(data.freeze()).unwrap();
+                    if let Err(e) = kcp.lock().send(data.freeze()) {
+                        tracing::error!(?e, "send data failed");
+                        return;
+                    }
                     kcp.lock().flush();
                     inner.update_notifier.notify_one();
                 }
@@ -206,7 +212,10 @@ impl KcpConnection {
         let kcp = self.kcp.clone();
         let inner = self.inner.clone();
         let conn_id = self.conn_id;
-        let recv_sender = self.recv_sender.take().unwrap();
+        let Some(recv_sender) = self.recv_sender.take() else {
+            tracing::error!("recv sender is not set");
+            return;
+        };
         let recv_closed = self.recv_closed.clone();
         self.tasks.spawn(
             async move {
@@ -222,7 +231,10 @@ impl KcpConnection {
                     if buf.capacity() < peeksize as usize {
                         buf.reserve(std::cmp::max(peeksize as usize, 4096));
                     }
-                    kcp.lock().recv(&mut buf).unwrap();
+                    if let Err(e) = kcp.lock().recv(&mut buf) {
+                        tracing::error!(?e, "recv data failed");
+                        return;
+                    }
                     tracing::trace!("recv data ({}): {:?}", buf.len(), buf);
                     assert_ne!(0, buf.len());
                     let send_ret = recv_sender.send(buf.split()).await;
@@ -246,12 +258,12 @@ impl KcpConnection {
         Ok(())
     }
 
-    fn send_sender(&mut self) -> KcpStreamSender {
-        self.send_sender.take().unwrap()
+    fn send_sender(&mut self) -> Option<KcpStreamSender> {
+        self.send_sender.take()
     }
 
-    fn recv_receiver(&mut self) -> KcpStreamReceiver {
-        self.recv_receiver.take().unwrap()
+    fn recv_receiver(&mut self) -> Option<KcpStreamReceiver> {
+        self.recv_receiver.take()
     }
 
     fn send_close_notifier(&self) -> Arc<Notify> {
@@ -500,7 +512,10 @@ impl KcpEndpoint {
     }
 
     pub async fn run(&mut self) {
-        let mut input_receiver = self.input_receiver.take().unwrap();
+        let Some(mut input_receiver) = self.input_receiver.take() else {
+            tracing::error!("input receiver is not set");
+            return;
+        };
         let data = self.data.clone();
         let output_sender = self.output_sender.clone();
         let new_conn_sender = self.new_conn_sender.clone();
@@ -553,12 +568,15 @@ impl KcpEndpoint {
                             data.state_map.insert(conv, conn_state);
                         }
                     } else {
-                        let state = state.unwrap();
+                        let Some(state) = state else {
+                            tracing::error!("no state for conn, ignore");
+                            return;
+                        };
                         let prev_established = state.is_established();
                         let ret = state.handle_packet(&packet);
                         tracing::trace!(?conv, ?state, "handle packet for conn, ret: {:?}", ret);
-                        if ret.is_ok() {
-                            out_packet = ret.unwrap();
+                        if let Ok(ret) = ret {
+                            out_packet = ret;
                         }
 
                         if !prev_established && state.is_established() {
@@ -665,7 +683,10 @@ impl KcpEndpoint {
             match close_ret {
                 Ok(_) => {
                     conn_id.fill_packet_header(&mut out_packet);
-                    output_sender.send(out_packet).await.unwrap();
+                    if let Err(e) = output_sender.send(out_packet).await {
+                        tracing::error!(?e, ?conn_id, "send close packet failed");
+                        return;
+                    }
                 }
                 Err(e) => {
                     tracing::error!(?e, ?conn_id, "close connection failed");
@@ -699,7 +720,15 @@ impl KcpEndpoint {
         conn_id: ConnId,
     ) -> Option<(KcpStreamSender, KcpStreamReceiver)> {
         let mut conn = self.data.conn_map.get_mut(&conn_id)?;
-        Some((conn.send_sender(), conn.recv_receiver()))
+        let Some(send_sender) = conn.send_sender() else {
+            tracing::error!("send sender is not set");
+            return None;
+        };
+        let Some(recv_receiver) = conn.recv_receiver() else {
+            tracing::error!("recv receiver is not set");
+            return None;
+        };
+        Some((send_sender, recv_receiver))
     }
 
     pub fn conn_data(&self, conn_id: &ConnId) -> Option<Bytes> {

--- a/src/ffi_safe.rs
+++ b/src/ffi_safe.rs
@@ -172,7 +172,11 @@ impl Kcp {
     }
 
     fn handle_output_callback(&self, buf: BytesMut) -> Result<(), Error> {
-        (self.output_cb.as_ref().unwrap())(self.config.conv, buf)
+        if let Some(output_cb) = self.output_cb.as_ref() {
+            output_cb(self.config.conv, buf)
+        } else {
+            Err(anyhow::anyhow!("no output callback set").into())
+        }
     }
 
     fn apply_config(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
1. Remove some `unwrap`. When error occurs,  `kcp.lock().send()` and `kcp.lock().recv()` will continue loop (not sure whether it is correct, need to make sure it doesn't go error), others will return. 
<img width="881" height="711" alt="image" src="https://github.com/user-attachments/assets/b1f3adcc-8261-4917-a9d0-de9ec451633e" />

2. Replace `tracing::error` to `log::error`/`log::warn`
3. Limit the length of data sent at a time and send it multiple times,   `max_chunk_size` combine https://github.com/skywind3000/kcp/blob/f4f3a89cc632647dabdcb146932d2afd5591e62e/ikcp.c#L512 and https://github.com/skywind3000/kcp/issues/428#issuecomment-2422542598


https://github.com/user-attachments/assets/9bee5d2e-0d4a-421b-94d2-f4b9dba494a0

